### PR TITLE
Patch which makes the module work in Python 3

### DIFF
--- a/sklearn_pandas/__init__.py
+++ b/sklearn_pandas/__init__.py
@@ -79,9 +79,15 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         Returns a numpy array with the data from the selected columns
         '''
         return_vector = False
-        if isinstance(cols, basestring):
-            return_vector = True
-            cols = [cols]
+
+        try:
+            if isinstance(cols, basestring):
+                return_vector = True
+                cols = [cols]
+        except NameError:
+            if isinstance(cols, str):
+                return_vector = True
+                cols = [cols]
 
         if isinstance(X, list):
             X = [x[cols] for x in X]


### PR DESCRIPTION
Here is a patch which makes the module work in Python 3.*.
`isinstance(basestring)` raises a NameError in Python 3.* because type of `basestring` is not supported.
