### PR TITLE
Raise KeyError when trying to select unexistent columns.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,12 @@ Sklearn-pandas' ``cross_val_score`` function provides exactly the same interface
 Changelog
 ---------
 
+0.0.14 (development)
+********************
+
+* Raise ``KeyError`` when selecting unexistent columns in the dataframe. Fixes #30.
+
+
 0.0.12 (2015-11-07)
 ********************
 

--- a/sklearn_pandas/__init__.py
+++ b/sklearn_pandas/__init__.py
@@ -109,7 +109,7 @@ class DataFrameMapper(BaseEstimator, TransformerMixin):
         if return_vector:
             t = X[cols[0]].values
         else:
-            t = X.as_matrix(cols)
+            t = X[cols].values
 
         return t
 

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -42,6 +42,15 @@ def cars_dataframe():
     return pd.read_csv("tests/test_data/cars.csv.gz", compression='gzip')
 
 
+def test_nonexistent_columns_explicit_fail(iris_dataframe):
+    """
+    If a nonexistent column is selected, KeyError is raised.
+    """
+    mapper = DataFrameMapper(None)
+    with pytest.raises(KeyError):
+        mapper._get_col_subset(iris_dataframe, ['nonexistent_feature'])
+
+
 def test_with_iris_dataframe(iris_dataframe):
     pipeline = Pipeline([
         ("preprocess", DataFrameMapper([


### PR DESCRIPTION
This is intended to fix https://github.com/paulgb/sklearn-pandas/issues/30