### PR TITLE
Correctly install and use mock module for python 2 and 3.

### DIFF
--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -1,5 +1,11 @@
 import pytest
-from mock import Mock
+
+# In py3, mock is included with the unittest standard library
+# In py2, it's a separate package
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from pandas import DataFrame
 import pandas as pd

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
      setuptools==16.0
      wheel==0.24.0
      flake8==2.4.1
+     py27: mock==1.3.0
 
 commands =
          pip install numpy --no-index


### PR DESCRIPTION
Last tests I wrote were using the "mock" library, which is an external library in python 2 and is included in the unittest module in python 3.

Here I install the "mock" package for the tox py27 environment and import mock from the correct place for both py27 and py34 in the sklearn_pandas test module.