### PR TITLE
Add `feature_indices_` attribute to mapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,17 @@ Now that the transformation is trained, we confirm that it works on new data::
     >>> np.round(mapper.transform(sample), 2)
     array([[ 1.  ,  0.  ,  0.  ,  1.04]])
 
+After transformation, the ``feature_indices_` attribute of the mapper
+indicates which columns of the resulting output array correspond to which
+input features. Input feature ``i`` is mapped to features from
+``feature_indices_[i]`` to ``feature_indices_[i+1]`` in transformed output.
+For example:
+
+    >>> mapper.feature_indices_[0], mapper.feature_indices_[1] # pet
+    (0, 3)
+    >>> mapper.feature_indices_[1], mapper.feature_indices_[2]  # children
+    (3, 4)
+
 Transform Multiple Columns
 **************************
 
@@ -195,6 +206,8 @@ Development
 
 * Deprecate custom cross-validation shim classes.
 * Require ``scikit-learn>=0.15.0``. Resolves #49.
+* Add ``feature_indices_`` attribute indicating the mapping between input and
+  ouptut variables.
 
 
 1.1.0 (2015-12-06)

--- a/sklearn_pandas/dataframe_mapper.py
+++ b/sklearn_pandas/dataframe_mapper.py
@@ -29,21 +29,32 @@ def _build_transformer(transformers):
 
 class DataFrameMapper(BaseEstimator, TransformerMixin):
     """
-    Map Pandas data frame column subsets to their own
-    sklearn transformation.
+    Map pandas DataFrame column subsets via sklearn transforms to feature
+    arrays.
+
+    Parameters
+    ----------
+        features : list of tuples of the form (column_selector, transform)
+            A column selector may be a string (for selecting a single column
+            as a 1-d array) or a list of string (for selecting one or more
+            columns as a 2-d array).
+            A transform is an object which supports sklearns' transform
+            interface, or a list of such objects.
+
+        sparse : bool, optional (default=False)
+            Return a sparse matrix if set True and any of the extracted
+            features are sparse.
+
+    Attributes
+    ----------
+        feature_indices_ : array of shape (len(self.features) + 1,)
+            Indices of self.features in the extracted array.
+            Feature ``i`` in self.features is mapped to features from
+            ``feature_indices_[i]`` to ``feature_indices_[i+1]`` in transformed
+            output.
     """
 
     def __init__(self, features, sparse=False):
-        """
-        Params:
-
-        features    a list of pairs. The first element is the pandas column
-                    selector. This can be a string (for one column) or a list
-                    of strings. The second element is an object that supports
-                    sklearn's transform interface, or a list of such objects.
-        sparse      will return sparse matrix if set True and any of the
-                    extracted features is sparse. Defaults to False.
-        """
         if isinstance(features, list):
             features = [(columns, _build_transformer(transformers))
                         for (columns, transformers) in features]


### PR DESCRIPTION
The attribute indicatesthe mapping between input and ouptut variables (see added docs). I'd like someone to give +1 before merging. :)  @asford ?

Differences with implementation in https://github.com/paulgb/sklearn-pandas/pull/54:

  * Instead of storing `self.feature_widths_` and calculating the `self.feature_indices_` property on the fly, here I store `self.feature_widths_` directly
  * The attribute is generated after the first transform, not after fitting. @asford implementation does `fit` and `transform` during the mapper `fit`. Since there is no reliable way to calculate the feature weights before applying the full transform, I prefer to leave the attribute unavailable until then. I don't know if it would be interesting to turn the attribute into a property to be able to raise a custom informative exception when some tries to access the attribute before transformation.

Thoughts?