### PR TITLE
Allow to provide custom column name for transformed feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ Transformation Mapping
 Map the Columns to Transformations
 **********************************
 
-The mapper takes a list of pairs. The first is a column name from the pandas DataFrame, or a list containing one or multiple columns (we will see an example with multiple columns later). The second is an object which will perform the transformation which will be applied to that column::
+The mapper takes a list of tuples. The first is a column name from the pandas DataFrame, or a list containing one or multiple columns (we will see an example with multiple columns later). The second is an object which will perform the transformation which will be applied to that column. The third is optional and is a dictionary containing the transformation options, if applicable (see "custom column names for transformed features" below).
+
+Let's see an example::
 
     >>> mapper = DataFrameMapper([
     ...     ('pet', sklearn.preprocessing.LabelBinarizer()),
@@ -114,6 +116,23 @@ the dataframe mapper. We can do so by inspecting the automatically generated
 
     >>> mapper.transformed_names_
     ['pet_cat', 'pet_dog', 'pet_fish', 'children']
+
+
+Custom column names for transformed features
+********************************************
+
+We can provide a custom name for the transformed features, to be used instead
+of the automatically generated one, by specifying it as the third argument
+of the feature definition::
+
+
+  >>> mapper_alias = DataFrameMapper([
+  ...     (['children'], sklearn.preprocessing.StandardScaler(),
+  ...      {'alias': 'children_scaled'})
+  ... ])
+  >>> _ = mapper_alias.fit_transform(data.copy())
+  >>> mapper_alias.transformed_names_
+  ['children_scaled']
 
 
 Passing Series/DataFrames to the transformers
@@ -317,6 +336,7 @@ Changelog
 
 Development
 ***********
+* Allow specifying a custom name (alias) for transformed columns (#83).
 * Capture output columns generated names in ``transformed_names_`` attribute (#78).
 * Add ``CategoricalImputer`` that replaces null-like values with the mode
   for string-like columns.

--- a/tests/test_dataframe_mapper.py
+++ b/tests/test_dataframe_mapper.py
@@ -127,6 +127,28 @@ def test_transformed_names_binarizer(complex_dataframe):
     mapper.transformed_names_ == ['target_a', 'target_b']
 
 
+def test_transformed_names_simple_alias(simple_dataframe):
+    """
+    If we specify an alias for a single output column, it is used for the
+    output
+    """
+    df = simple_dataframe
+    mapper = DataFrameMapper([('a', None, {'alias': 'new_name'})])
+    mapper.fit_transform(df)
+    assert mapper.transformed_names_ == ['new_name']
+
+
+def test_transformed_names_complex_alias(complex_dataframe):
+    """
+    If we specify an alias for a multiple output column, it is used for the
+    output
+    """
+    df = complex_dataframe
+    mapper = DataFrameMapper([('target', LabelBinarizer(), {'alias': 'new'})])
+    mapper.fit_transform(df)
+    mapper.transformed_names_ == ['new_a', 'new_b']
+
+
 def test_simple_df(simple_dataframe):
     """
     Get a dataframe from a simple mapped dataframe


### PR DESCRIPTION
Sometimes you want to generate different features based on same column. For instance you want to transform datetime into Day of Week and Hour Of Day feature. In this case both the features will end up having the same name as the original column. Hence you want to provide an alias. ex

```
step1 = []
step1.append(('started_at', DayOfWeek(), {'alias': 'DOW'}))
step1.append(('started_at', HourOfDay(), {'alias': 'HOD'}))
DataFrameMapper(step1, df_out=True, default=False))
```

Implements #83.